### PR TITLE
feat: Implement flexible stock symbol handling

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -1,0 +1,114 @@
+import pandas as pd
+import argparse
+import numpy as np
+import sys
+
+from data_fetcher import fetch_stock_data
+from return_calculator import calculate_returns
+
+def process_input_csv(input_csv_path: str, output_csv_path: str):
+    """
+    Reads an input CSV with stock symbols and identification dates,
+    fetches historical data, calculates returns, and saves results to an output CSV.
+
+    Args:
+        input_csv_path: Path to the input CSV file.
+                        Expected columns: 'Symbol', 'Date' (YYYY-MM-DD).
+        output_csv_path: Path to save the output CSV file.
+    """
+    try:
+        input_df = pd.read_csv(input_csv_path)
+    except FileNotFoundError:
+        print(f"Error: Input file not found at {input_csv_path}", file=sys.stderr)
+        sys.exit(1)
+    except pd.errors.EmptyDataError:
+        print(f"Error: Input file {input_csv_path} is empty.", file=sys.stderr)
+        sys.exit(1)
+    except pd.errors.ParserError:
+        print(f"Error: Could not parse input file {input_csv_path}. Check CSV formatting.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading input CSV {input_csv_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not {'Symbol', 'Date'}.issubset(input_df.columns):
+        print(f"Error: Input CSV {input_csv_path} must contain 'Symbol' and 'Date' columns.", file=sys.stderr)
+        sys.exit(1)
+
+    results_list = []
+
+    for index, row in input_df.iterrows():
+        original_symbol_from_csv = str(row['Symbol'])
+        identification_date = str(row['Date']) # Ensure it's a string for the functions
+
+        # Call fetch_stock_data and unpack both return values
+        historical_data, resolved_symbol = fetch_stock_data(original_symbol_from_csv, identification_date)
+
+        returns_dict = {'1W': np.nan, '1M': np.nan, '3M': np.nan} # Default to NaN
+
+        if historical_data is not None and not historical_data.empty and resolved_symbol is not None:
+            # Data fetched successfully
+            print(f"Processing {resolved_symbol} (identified as '{original_symbol_from_csv}' on {identification_date})...")
+            
+            # Ensure the date format passed to calculate_returns is YYYY-MM-DD
+            # The 'identification_date' from CSV is already in this format.
+            calculated_returns = calculate_returns(historical_data, identification_date)
+            returns_dict.update(calculated_returns) # Update with actual returns if calculated
+        else:
+            # Data fetching failed or returned empty/None
+            print(f"Failed to fetch data for {original_symbol_from_csv} identified on {identification_date} after trying relevant suffixes. Using NaN for returns.", file=sys.stderr)
+            # returns_dict remains as all NaNs
+
+        result_row = {
+            'Symbol': original_symbol_from_csv, # Store the original symbol from CSV
+            'Date': identification_date,
+            '1W_Return': returns_dict.get('1W', np.nan),
+            '1M_Return': returns_dict.get('1M', np.nan),
+            '3M_Return': returns_dict.get('3M', np.nan)
+        }
+        results_list.append(result_row)
+
+    if not results_list:
+        print("No data processed. Output file will be empty or not created.")
+        # Depending on desired behavior, one might still want to create an empty CSV with headers
+        # For now, if results_list is empty, an empty DataFrame will be created and saved.
+
+    output_df = pd.DataFrame(results_list)
+    
+    try:
+        output_df.to_csv(output_csv_path, index=False)
+        print(f"Backtest complete. Results saved to {output_csv_path}")
+    except Exception as e:
+        print(f"Error saving output CSV to {output_csv_path}: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Stock Backtester")
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=str,
+        required=True,
+        help="Path to the input CSV file. Expected columns: 'Symbol', 'Date'."
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        required=True,
+        help="Path to the output CSV file for saving results."
+    )
+
+    args = parser.parse_args()
+
+    process_input_csv(args.input, args.output)
+
+    # Example to create a dummy input CSV for testing:
+    # if not os.path.exists("dummy_input.csv"):
+    #     dummy_data = {
+    #         'Symbol': ["RELIANCE.NS", "TCS.NS", "INFY.NS", "NONEXISTENT.NS"],
+    #         'Date': ["2023-01-01", "2023-02-01", "2022-11-15", "2023-01-01"]
+    #     }
+    #     dummy_df = pd.DataFrame(dummy_data)
+    #     dummy_df.to_csv("dummy_input.csv", index=False)
+    #     print("Created dummy_input.csv for testing. Run again with: python backtester.py -i dummy_input.csv -o output_results.csv")

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,67 @@
+import yfinance as yf
+import pandas as pd
+from datetime import datetime, timedelta
+import sys
+
+def fetch_stock_data(symbol: str, start_date_str: str) -> tuple[pd.DataFrame | None, str | None]:
+    """
+    Fetches historical stock data for a given symbol and start date.
+    Tries .NS and .BO suffixes if no suffix is provided and the symbol is not found.
+
+    Args:
+        symbol: The stock symbol (e.g., "RELIANCE", "RELIANCE.NS").
+        start_date_str: The start date string (e.g., "2023-01-01").
+
+    Returns:
+        A tuple containing:
+        - A pandas DataFrame with historical stock data, or None if an error occurs.
+        - The symbol string that was successfully used to fetch data, or None if fetching failed.
+    """
+    original_symbol = symbol
+    upper_symbol = symbol.upper()
+    
+    symbols_to_attempt = []
+
+    if upper_symbol.endswith(".NS") or upper_symbol.endswith(".BO"):
+        symbols_to_attempt = [upper_symbol]
+    else:
+        symbols_to_attempt = [upper_symbol + ".NS", upper_symbol + ".BO"]
+
+    try:
+        start_datetime = datetime.strptime(start_date_str, "%Y-%m-%d")
+        # Calculate end_date approximately 4 months after start_date
+        end_datetime = start_datetime + timedelta(days=4 * 30)
+    except ValueError as e:
+        print(f"Error: Invalid date format for start_date_str '{start_date_str}'. Expected YYYY-MM-DD. Details: {e}", file=sys.stderr)
+        return None, None
+
+    for attempt_symbol in symbols_to_attempt:
+        print(f"Trying to fetch data for symbol: {attempt_symbol}", file=sys.stderr)
+        try:
+            ticker = yf.Ticker(attempt_symbol)
+            # The yfinance library can sometimes raise exceptions for various reasons,
+            # including network issues or invalid symbols that aren't caught by .history() returning empty.
+            # A common pattern for yfinance is that .history() might return an empty DataFrame
+            # for symbols that exist but have no data in the range, or for invalid symbols.
+            data = ticker.history(start=start_datetime.strftime("%Y-%m-%d"), end=end_datetime.strftime("%Y-%m-%d"))
+
+            if not data.empty:
+                print(f"Successfully fetched data for {attempt_symbol}", file=sys.stderr)
+                return data, attempt_symbol
+            else:
+                # This handles cases where the symbol is valid but no data for the period,
+                # or yfinance returns empty for some types of invalid symbols.
+                print(f"Failed to fetch data for {attempt_symbol}: No data returned.", file=sys.stderr)
+        
+        except Exception as e:
+            # This catches other errors during yf.Ticker() or ticker.history() call
+            # For example, network errors, or sometimes yfinance raises specific errors for truly bad symbols.
+            print(f"Failed to fetch data for {attempt_symbol}: An error occurred: {e}", file=sys.stderr)
+            # We continue to the next symbol in the list.
+
+    # If loop completes, all attempts failed
+    print(f"All attempts to fetch data for original symbol '{original_symbol}' (tried: {', '.join(symbols_to_attempt)}) failed.", file=sys.stderr)
+    return None, None
+
+# The __main__ block has been removed as per the subtask instructions.
+# Unit tests are now in test_data_fetcher.py

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+import sys
+from data_fetcher import fetch_stock_data
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: python main.py <stock_symbol> <start_date_YYYY-MM-DD>")
+        sys.exit(1)
+
+    symbol = sys.argv[1]
+    start_date = sys.argv[2]
+
+    print(f"Fetching stock data for {symbol} from {start_date}...")
+    stock_data_df = fetch_stock_data(symbol, start_date)
+
+    if stock_data_df is not None:
+        print("Data fetched successfully:")
+        print(stock_data_df.head())
+    else:
+        print(f"Failed to fetch stock data for {symbol}.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+yfinance
+numpy

--- a/return_calculator.py
+++ b/return_calculator.py
@@ -1,0 +1,82 @@
+import pandas as pd
+import numpy as np
+from pandas.tseries.offsets import DateOffset
+
+def get_price_on_or_after(date: pd.Timestamp, data: pd.DataFrame) -> float | None:
+    """
+    Helper function to get the closing price on or after a given date.
+    """
+    if data.empty:
+        return None
+    # Filter data from the given date onwards
+    future_data = data[data.index >= date]
+    if future_data.empty:
+        return None
+    return future_data.iloc[0]['Close']
+
+def calculate_returns(historical_data: pd.DataFrame, identification_date_str: str) -> dict:
+    """
+    Calculates stock returns for 1-week, 1-month, and 3-month periods
+    from an identification date.
+
+    Args:
+        historical_data: Pandas DataFrame with DateTimeIndex and 'Close' prices.
+        identification_date_str: The date string (e.g., "2023-01-01")
+                                   when the stock was identified.
+
+    Returns:
+        A dictionary containing the calculated returns:
+        {'1W': <return_1_week_percentage>,
+         '1M': <return_1_month_percentage>,
+         '3M': <return_3_months_percentage>}
+        Uses numpy.nan for any returns that could not be calculated.
+    """
+    returns = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+
+    if historical_data is None or historical_data.empty:
+        return returns
+
+    try:
+        t_0 = pd.Timestamp(identification_date_str)
+    except ValueError:
+        # Handle invalid date string format if necessary, though Timestamp is quite robust
+        print(f"Error: Invalid identification_date_str format: {identification_date_str}")
+        return returns
+        
+    # Ensure the index is timezone-naive if t_0 is timezone-naive, or localize t_0
+    if historical_data.index.tz is not None and t_0.tz is None:
+        t_0 = t_0.tz_localize(historical_data.index.tz)
+    elif historical_data.index.tz is None and t_0.tz is not None:
+        t_0 = t_0.tz_localize(None)
+
+
+    price_t_0 = get_price_on_or_after(t_0, historical_data)
+
+    if price_t_0 is None:
+        return returns # All NaN as per requirement
+
+    # Target dates
+    t_1W = t_0 + pd.Timedelta(days=7)
+    t_1M = t_0 + DateOffset(months=1)
+    t_3M = t_0 + DateOffset(months=3)
+
+    # Prices at target dates
+    price_t_1W = get_price_on_or_after(t_1W, historical_data)
+    price_t_1M = get_price_on_or_after(t_1M, historical_data)
+    price_t_3M = get_price_on_or_after(t_3M, historical_data)
+
+    # Calculate returns
+    if price_t_1W is not None:
+        returns['1W'] = ((price_t_1W / price_t_0) - 1) * 100
+    
+    if price_t_1M is not None:
+        returns['1M'] = ((price_t_1M / price_t_0) - 1) * 100
+
+    if price_t_3M is not None:
+        returns['3M'] = ((price_t_3M / price_t_0) - 1) * 100
+
+    return returns
+
+# End of calculate_returns function
+# The test code previously under if __name__ == "__main__": has been moved to test_return_calculator.py
+```

--- a/test_data_fetcher.py
+++ b/test_data_fetcher.py
@@ -1,0 +1,205 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+import sys
+from io import StringIO
+
+# Assuming data_fetcher.py is in the same directory or accessible via PYTHONPATH
+from data_fetcher import fetch_stock_data
+
+# Helper function to create a sample DataFrame
+def create_sample_df():
+    return pd.DataFrame({'Close': [100, 101, 102]})
+
+class TestDataFetcher(unittest.TestCase):
+
+    def setUp(self):
+        # Redirect stderr to capture print statements for some tests
+        self.held_stderr = sys.stderr
+        sys.stderr = StringIO()
+
+    def tearDown(self):
+        # Restore stderr
+        sys.stderr = self.held_stderr
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_fetch_success_ns_suffix(self, mock_ticker):
+        # a. Successful fetch with .NS suffix
+        sample_df = create_sample_df()
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = sample_df
+        
+        # Configure the mock_ticker to return different instances based on symbol
+        def ticker_side_effect(symbol_arg):
+            if symbol_arg == "RELIANCE.NS":
+                return mock_instance
+            # Add more conditions if other symbols are tried in this test, though not expected
+            return MagicMock(history=MagicMock(return_value=pd.DataFrame())) # Default empty for others
+
+        mock_ticker.side_effect = ticker_side_effect
+        
+        df, resolved_symbol = fetch_stock_data("reliance", "2023-01-01")
+        
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "RELIANCE.NS")
+        mock_ticker.assert_any_call("RELIANCE.NS")
+
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_fetch_success_bo_suffix(self, mock_ticker):
+        # b. Successful fetch with .BO suffix (after .NS fails)
+        sample_df = create_sample_df()
+        
+        mock_ns_instance = MagicMock()
+        mock_ns_instance.history.return_value = pd.DataFrame() # .NS returns empty
+
+        mock_bo_instance = MagicMock()
+        mock_bo_instance.history.return_value = sample_df # .BO returns data
+        
+        def ticker_side_effect(symbol_arg):
+            if symbol_arg == "MYCOMPANY.NS":
+                return mock_ns_instance
+            elif symbol_arg == "MYCOMPANY.BO":
+                return mock_bo_instance
+            return MagicMock(history=MagicMock(return_value=pd.DataFrame()))
+
+        mock_ticker.side_effect = ticker_side_effect
+        
+        df, resolved_symbol = fetch_stock_data("mycompany", "2023-01-01")
+        
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "MYCOMPANY.BO")
+        mock_ticker.assert_any_call("MYCOMPANY.NS")
+        mock_ticker.assert_any_call("MYCOMPANY.BO")
+
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_symbol_already_has_ns_suffix(self, mock_ticker):
+        # c. Symbol already has .NS suffix (correct case)
+        sample_df = create_sample_df()
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = sample_df
+        mock_ticker.return_value = mock_instance # Only INFY.NS should be called
+
+        df, resolved_symbol = fetch_stock_data("INFY.NS", "2023-01-01")
+
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "INFY.NS")
+        mock_ticker.assert_called_once_with("INFY.NS")
+
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_symbol_already_has_bo_suffix_mixed_case(self, mock_ticker):
+        # d. Symbol already has .BO suffix (mixed case)
+        sample_df = create_sample_df()
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = sample_df
+        mock_ticker.return_value = mock_instance # Only ASIANPAINT.BO should be called
+
+        df, resolved_symbol = fetch_stock_data("asianpaint.bo", "2023-01-01")
+
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "ASIANPAINT.BO")
+        mock_ticker.assert_called_once_with("ASIANPAINT.BO")
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_fetching_fails_for_all_attempts(self, mock_ticker):
+        # e. Fetching fails for all attempts
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = pd.DataFrame() # Empty DataFrame for all attempts
+        mock_ticker.return_value = mock_instance
+
+        df, resolved_symbol = fetch_stock_data("nonexistentsymbol", "2023-01-01")
+
+        self.assertIsNone(df)
+        self.assertIsNone(resolved_symbol)
+        mock_ticker.assert_any_call("NONEXISTENTSYMBOL.NS")
+        mock_ticker.assert_any_call("NONEXISTENTSYMBOL.BO")
+        self.assertEqual(mock_ticker.call_count, 2)
+
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_fetching_fails_for_qualified_non_existent_symbol(self, mock_ticker):
+        # f. Fetching fails for an already qualified but non-existent symbol
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = pd.DataFrame() # Empty DataFrame
+        mock_ticker.return_value = mock_instance
+
+        df, resolved_symbol = fetch_stock_data("FAKESYMBOL.NS", "2023-01-01")
+
+        self.assertIsNone(df)
+        self.assertIsNone(resolved_symbol)
+        mock_ticker.assert_called_once_with("FAKESYMBOL.NS")
+
+    # No mock needed if date validation happens before Ticker call
+    def test_invalid_date_format_string(self):
+        # g. Invalid date format string
+        # This test does not mock yf.Ticker as the function should fail before that.
+        df, resolved_symbol = fetch_stock_data("RELIANCE", "2023/01/01")
+
+        self.assertIsNone(df)
+        self.assertIsNone(resolved_symbol)
+        # Check stderr for the specific error message
+        # self.assertIn("Error: Invalid date format for start_date_str '2023/01/01'", sys.stderr.getvalue())
+        # Note: Checking stderr can be brittle. The primary check is the None return.
+        # The data_fetcher already prints to stderr, so this is more of an integration check of that.
+
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_case_sensitivity_resolves_uppercase(self, mock_ticker):
+        # h. Test case sensitivity (input lowercase, resolves to uppercase)
+        sample_df = create_sample_df()
+        mock_instance = MagicMock()
+        mock_instance.history.return_value = sample_df
+        
+        def ticker_side_effect(symbol_arg):
+            if symbol_arg == "TCS.NS":
+                return mock_instance
+            return MagicMock(history=MagicMock(return_value=pd.DataFrame()))
+
+        mock_ticker.side_effect = ticker_side_effect
+
+        df, resolved_symbol = fetch_stock_data("tcs", "2023-01-01")
+
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "TCS.NS")
+        mock_ticker.assert_any_call("TCS.NS")
+        # Depending on implementation, TCS.BO might or might not be called if TCS.NS is found first.
+        # If TCS.NS is found, the loop should break.
+
+    @patch('data_fetcher.yf.Ticker')
+    def test_ns_fails_with_exception_bo_succeeds(self, mock_ticker):
+        # Test case where .NS attempt raises an exception
+        sample_df = create_sample_df()
+        
+        mock_ns_instance = MagicMock()
+        mock_ns_instance.history.side_effect = Exception("Simulated yfinance error for NS")
+
+        mock_bo_instance = MagicMock()
+        mock_bo_instance.history.return_value = sample_df # .BO returns data
+        
+        def ticker_side_effect(symbol_arg):
+            if symbol_arg == "ERRORSTOCK.NS":
+                return mock_ns_instance
+            elif symbol_arg == "ERRORSTOCK.BO":
+                return mock_bo_instance
+            return MagicMock(history=MagicMock(return_value=pd.DataFrame()))
+
+        mock_ticker.side_effect = ticker_side_effect
+        
+        df, resolved_symbol = fetch_stock_data("errorstock", "2023-01-01")
+        
+        self.assertIsNotNone(df)
+        pd.testing.assert_frame_equal(df, sample_df)
+        self.assertEqual(resolved_symbol, "ERRORSTOCK.BO")
+        mock_ticker.assert_any_call("ERRORSTOCK.NS")
+        mock_ticker.assert_any_call("ERRORSTOCK.BO")
+
+if __name__ == "__main__":
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+```

--- a/test_return_calculator.py
+++ b/test_return_calculator.py
@@ -1,0 +1,191 @@
+import unittest
+import pandas as pd
+import numpy as np
+from pandas.tseries.offsets import DateOffset # Needed for test data generation if replicating logic
+from datetime import datetime
+
+# Assuming return_calculator.py is in the same directory or accessible via PYTHONPATH
+from return_calculator import calculate_returns 
+
+class TestReturnCalculator(unittest.TestCase):
+
+    def assertReturnDictsClose(self, dict1, dict2, msg=None):
+        """
+        Asserts that two dictionaries of returns are close.
+        Compares keys and checks for np.nan equality for float values.
+        """
+        self.assertEqual(set(dict1.keys()), set(dict2.keys()), msg=f"Keys differ: {msg}" if msg else "Keys differ")
+        for key in dict1:
+            val1 = dict1[key]
+            val2 = dict2[key]
+            if isinstance(val1, float) and isinstance(val2, float):
+                if np.isnan(val1) and np.isnan(val2):
+                    continue # Both are NaN, considered equal for this purpose
+                self.assertAlmostEqual(val1, val2, places=5, msg=f"Floats differ for key '{key}': {msg}" if msg else f"Floats differ for key '{key}'")
+            else:
+                self.assertEqual(val1, val2, msg=f"Values differ for key '{key}': {msg}" if msg else f"Values differ for key '{key}'")
+
+    @classmethod
+    def setUpClass(cls):
+        # This sample data can be used by multiple tests
+        # More specific data can be created within each test method if needed
+        dates = pd.to_datetime([
+            "2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04", "2023-01-05", # P_t0 = 102 (idx 2)
+            "2023-01-08", "2023-01-09", "2023-01-10", "2023-01-11", "2023-01-12", # P_t1W = 107 (idx 7)
+            "2023-01-30", "2023-01-31", "2023-02-01", "2023-02-02", "2023-02-03", # P_t1M = 114 (idx 14)
+            "2023-03-28", "2023-03-29", "2023-03-30", "2023-03-31", "2023-04-03", # P_t3M = 120 (idx 19)
+            "2023-04-04", "2023-04-05"
+        ])
+        closes = [
+            100, 101, 102, 103, 104,  # Jan 1-5
+            105, 106, 107, 108, 109,  # Jan 8-12
+            110, 111, 112, 113, 114,  # Jan 30 - Feb 3
+            115, 116, 117, 118, 120,  # Mar 28 - Apr 3
+            121, 122                   # Apr 4-5
+        ]
+        cls.sample_data = pd.DataFrame({'Close': closes}, index=dates)
+
+    def test_basic_calculation(self):
+        # Test Case 1 from original: Identification date is a trading day
+        # t_0 = 2023-01-03 (Price 102)
+        # t_1W = 2023-01-10 (Price 107) -> (107/102 - 1)*100 = 4.90196%
+        # t_1M = 2023-02-03 (Price 114) -> (114/102 - 1)*100 = 11.7647% (DateOffset makes it 2023-02-03)
+        # t_3M = 2023-04-03 (Price 120) -> (120/102 - 1)*100 = 17.64705% (DateOffset makes it 2023-04-03)
+        results = calculate_returns(self.sample_data, "2023-01-03")
+        expected = {'1W': 4.90196, '1M': 11.76471, '3M': 17.64706}
+        self.assertReturnDictsClose(results, expected, "Test Case 1: Basic Calculation")
+
+    def test_identification_date_not_trading_day(self):
+        # Test Case 2: Identification date not a trading day
+        # Original ID date: "2023-01-06" (Fri). Next trading day in sample_data is "2023-01-08" (Price 105)
+        # t_0 = 2023-01-08 (Price 105)
+        # t_1W = 2023-01-08 + 7 days = 2023-01-15. Next available: 2023-01-30 (Price 110)
+        # Return: (110/105 - 1)*100 = 4.76190%
+        # t_1M = 2023-01-08 + 1 month = 2023-02-08. Next available: 2023-02-01 (Price 112) - this was an error in original reasoning.
+        # Corrected: t_1M from 2023-01-08 is 2023-02-08. Next available in data is 2023-03-28 (Price 115) - still seems off.
+        # Let's use the logic: date = 2023-01-08 (P=105). 1M target: 2023-02-08. In sample_data, after 2023-02-08 is 2023-03-28 (P=115).
+        # (115/105 - 1)*100 = 9.52381%
+
+        # t_3M = 2023-01-08 + 3 months = 2023-04-08. Next available: 2023-04-03 (P=120) - again, error in original, should be future.
+        # Corrected: t_3M from 2023-01-08 is 2023-04-08. Next available in data is 2023-04-04 (P=121)
+        # (121/105 - 1)*100 = 15.23809%
+        results = calculate_returns(self.sample_data, "2023-01-06") # Friday, data has 2023-01-08 as next
+        expected = {'1W': (107/105-1)*100, # P_t0=105 (01-08), P_t1W=107 (01-10, which is closest to 01-08 + 7days=01-15)
+                    '1M': (112/105-1)*100, # P_t1M=112 (02-01, which is closest to 01-08 + 1M=02-08)
+                    '3M': (120/105-1)*100} # P_t3M=120 (04-03, which is closest to 01-08 + 3M=04-08)
+
+        # Re-evaluating based on get_price_on_or_after implementation:
+        # t0: 2023-01-08 (Price 105)
+        # t_1W: 2023-01-15 -> get_price_on_or_after -> 2023-01-30 (Price 110) -> (110/105 - 1)*100 = 4.76190%
+        # t_1M: 2023-02-08 -> get_price_on_or_after -> 2023-03-28 (Price 115) -> (115/105 - 1)*100 = 9.52381%
+        # t_3M: 2023-04-08 -> get_price_on_or_after -> 2023-04-04 (Price 121) -> (121/105 - 1)*100 = 15.23809%
+        # The original script's Test Case 2 output was: {'1W': 4.76190, '1M': 9.52381, '3M': 15.2381}
+        # This matches the re-evaluation.
+
+        expected = {'1W': 4.76190, '1M': 9.52381, '3M': 15.23810}
+        self.assertReturnDictsClose(results, expected, "Test Case 2: Identification date not trading day")
+
+    def test_data_too_short_for_3m_return(self):
+        # Test Case 3 from original
+        short_data = self.sample_data[self.sample_data.index < "2023-03-01"]
+        # t_0 = 2023-01-03 (Price 102)
+        # t_1W = 2023-01-10 (Price 107) -> 4.90196%
+        # t_1M = 2023-02-03 (Price 114) -> 11.76471%
+        # t_3M = 2023-04-03 (No data in short_data) -> NaN
+        results = calculate_returns(short_data, "2023-01-03")
+        expected = {'1W': 4.90196, '1M': 11.76471, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 3: Data too short for 3M")
+
+    def test_identification_date_at_very_end(self):
+        # Test Case 4 from original
+        # t_0 = 2023-04-05 (Price 122)
+        # t_1W, t_1M, t_3M will all be NaN as no future data.
+        results = calculate_returns(self.sample_data, "2023-04-05")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 4: Identification date at very end")
+
+    def test_identification_date_after_all_data(self):
+        # Test Case 5 from original
+        # t_0 price will be None. All returns NaN.
+        results = calculate_returns(self.sample_data, "2023-05-01")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 5: Identification date after all data")
+
+    def test_empty_dataframe(self):
+        # Test Case 6 from original
+        empty_df = pd.DataFrame({'Close': []}, index=pd.to_datetime([]))
+        results = calculate_returns(empty_df, "2023-01-01")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 6: Empty DataFrame")
+
+    def test_identification_date_no_data_on_or_after_t0(self):
+        # Test Case 7 from original
+        data_ends_early = self.sample_data[self.sample_data.index < "2023-01-02"] # Data only for 2023-01-01
+        results = calculate_returns(data_ends_early, "2023-01-03")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 7: No data at or after t0")
+
+    def test_timezone_aware_data(self):
+        # Test Case 9 from original
+        sample_data_tz = self.sample_data.copy()
+        sample_data_tz.index = sample_data_tz.index.tz_localize('UTC')
+        results = calculate_returns(sample_data_tz, "2023-01-03") # identification_date_str is naive
+        # Expected results should be same as Test Case 1
+        expected = {'1W': 4.90196, '1M': 11.76471, '3M': 17.64706}
+        self.assertReturnDictsClose(results, expected, "Test Case 9: Timezone-aware data")
+
+    def test_invalid_identification_date_format(self):
+        # Test Case 10 from original
+        results = calculate_returns(self.sample_data, "invalid-date-format")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 10: Invalid date format")
+
+    def test_target_date_lands_on_non_trading_day(self):
+        # Test Case 11 from original
+        dates_missing_targets = pd.to_datetime([
+            "2023-01-01", # t0 (Price 100)
+            "2023-01-08", # t_1W (Jan 1 + 7 days) (Price 105)
+            # "2023-02-01", # t_1M (Jan 1 + 1 month) is missing
+            "2023-02-02", # Next available for t_1M (Price 110)
+            # "2023-04-01", # t_3M (Jan 1 + 3 months) is missing
+            "2023-04-03", # Next available for t_3M (Price 120)
+        ])
+        closes_missing_targets = [100, 105, 110, 120]
+        data = pd.DataFrame({'Close': closes_missing_targets}, index=dates_missing_targets)
+        
+        results = calculate_returns(data, "2023-01-01")
+        # t0: 2023-01-01 (Price 100)
+        # t_1W: 2023-01-08 (Price 105) -> (105/100 - 1)*100 = 5.0%
+        # t_1M: 2023-02-01 -> next is 2023-02-02 (Price 110) -> (110/100 - 1)*100 = 10.0%
+        # t_3M: 2023-04-01 -> next is 2023-04-03 (Price 120) -> (120/100 - 1)*100 = 20.0%
+        expected = {'1W': 5.0, '1M': 10.0, '3M': 20.0}
+        self.assertReturnDictsClose(results, expected, "Test Case 11: Target date non-trading day")
+
+    def test_all_target_dates_outside_range(self):
+        # Test Case 12 from original
+        one_day_data = pd.DataFrame({'Close': [100]}, index=pd.to_datetime(["2023-01-01"]))
+        results = calculate_returns(one_day_data, "2023-01-01")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 12: All targets outside range")
+
+    def test_historical_data_is_none(self):
+        # Test Case 13 from original
+        results = calculate_returns(None, "2023-01-01")
+        expected = {'1W': np.nan, '1M': np.nan, '3M': np.nan}
+        self.assertReturnDictsClose(results, expected, "Test Case 13: historical_data is None")
+
+    def test_specific_check_next_available_trading_day_for_target(self):
+        # Test Case 8 from original
+        # t_0: 2023-01-02 (Price 101)
+        # t_1W: 2023-01-09 (Price 106) -> (106/101 - 1)*100 = 4.950495%
+        # t_1M: 2023-02-02 (Price 113) -> (113/101 - 1)*100 = 11.881188%
+        # t_3M: 2023-04-02 -> next is 2023-04-03 (Price 120) -> (120/101 - 1)*100 = 18.811881%
+        results = calculate_returns(self.sample_data, "2023-01-02")
+        expected = {'1W': 4.95050, '1M': 11.88119, '3M': 18.81188}
+        self.assertReturnDictsClose(results, expected, "Test Case 8: Specific next available day check")
+
+
+if __name__ == "__main__":
+    unittest.main(argv=['first-arg-is-ignored'], exit=False) # For running in environments like Jupyter
+    # To run from command line: python -m unittest test_return_calculator.py
+```


### PR DESCRIPTION
This commit enhances the backtester to automatically handle variations in stock symbol inputs.

Key changes:
- `data_fetcher.py`:
    - The `fetch_stock_data` function now converts input symbols to uppercase.
    - If a symbol doesn't have an exchange suffix (.NS or .BO), it attempts to fetch data by first appending .NS, and then .BO if the .NS attempt fails.
    - The function now returns a tuple `(DataFrame, resolved_symbol_str)`, where `resolved_symbol_str` is the actual symbol variant that successfully fetched data.
- `test_data_fetcher.py`:
    - Added a new test suite for `data_fetcher.py` using `unittest` and `unittest.mock.patch` to cover various symbol input scenarios (lowercase, uppercase, no suffix, existing suffix, .NS/.BO fallback logic, non-existent symbols).
- `backtester.py`:
    - Updated to use the new two-value return from `fetch_stock_data`.
    - Console log messages now display the `resolved_symbol` that was used for data fetching, while still referencing your original input symbol from the CSV.
    - The 'Symbol' column in the output CSV remains your original input for consistency.
- The `if __name__ == "__main__":` test block was removed from `data_fetcher.py` in favor of the dedicated unit test file.

This improvement makes the tool more user-friendly by reducing the need for you to pre-format symbols with exact Yahoo Finance exchange suffixes.